### PR TITLE
Mark package not-installable on Windows / Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "type": "git",
     "url": "https://github.com/CharlieHess/node-mac-notifier"
   },
+  "os": ["darwin"],
   "author": "Charlie Hess",
   "devDependencies": {
     "nan": "^2.0.5",


### PR DESCRIPTION
Otherwise, even if you put it in `optionalDependencies` which _should_ work, it halts `npm install`