### PR TITLE
Ensure Delegate Hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 node_modules
 npm-debug.log
 .DS_Store
+.vscode

--- a/index.js
+++ b/index.js
@@ -35,22 +35,30 @@ module.exports = class Notification extends EventTarget {
   }
 
   close() {
-    if (notifications && notifications.length > 0) {
-      let i = this.getNotificationIndexById(this.notification.id);
-      if (i) notifications.splice(i, 1);
-    }
-
     this.notification.close();
     this.notification = null;
     
     this.dispatchEvent({type: 'close'});
+
+    if (this.notification && notifications && notifications.length > 0) {
+      let i = this.getNotificationIndexById(this.notification.id);
+      if (i) notifications.splice(i, 1);
+    }
   }
 
   getNotificationById(id) {
-    return notifications.find((item) => (item.notification.id === id));
+    return notifications.find((item) => this.compareItemWithId(item, id));
   }
 
   getNotificationIndexById(id) {
-    return notifications.findIndex((item) => (item.notification.id === id));
+    return notifications.findIndex((item) => this.compareItemWithId(item, id));
+  }
+
+  compareItemWithId(item, id) {
+    if (item && item.notification && item.notification.id) {
+      return item.notification.id === id;
+    } else {
+      return false;
+    }
   }
 };

--- a/index.js
+++ b/index.js
@@ -19,7 +19,10 @@ module.exports = class Notification extends EventTarget {
     options.canReply = !!options.canReply;
 
     let activated = (isReply, response, id) => {
-      const notification = this.getNotificationById(id) || this;
+      const notification = this.getNotificationById(id);
+      if (!notification) return;
+
+      console.log(notifications);
       
       if (isReply) {
         notification.dispatchEvent({type: 'reply', response});

--- a/index.js
+++ b/index.js
@@ -35,8 +35,10 @@ module.exports = class Notification extends EventTarget {
   }
 
   close() {
-    let i = getNotificationIndexById(this.notification.id);
-    if (i) notifications.splice(i, 1);
+    if (notifications && notifications.length > 0) {
+      let i = this.getNotificationIndexById(this.notification.id);
+      if (i) notifications.splice(i, 1);
+    }
 
     this.notification.close();
     this.notification = null;

--- a/index.js
+++ b/index.js
@@ -21,8 +21,6 @@ module.exports = class Notification extends EventTarget {
     let activated = (isReply, response, id) => {
       const notification = this.getNotificationById(id);
       if (!notification) return;
-
-      console.log(notifications);
       
       if (isReply) {
         notification.dispatchEvent({type: 'reply', response});

--- a/mac_notification.mm
+++ b/mac_notification.mm
@@ -109,7 +109,6 @@ NAN_METHOD(MacNotification::Close) {
   NSString *identifier = [NSString stringWithUTF8String:**(notification->_id)];
 
   NSUserNotificationCenter *center = [NSUserNotificationCenter defaultUserNotificationCenter];
-  center.delegate = nil;
 
   for (NSUserNotification *notification in center.deliveredNotifications) {
     if ([notification.identifier isEqualToString:identifier]) {

--- a/notification_center_delegate.h
+++ b/notification_center_delegate.h
@@ -7,6 +7,7 @@ struct NotificationActivationInfo {
   Nan::Callback *callback;
   bool isReply;
   const char *response;
+  const char *id;
 };
 
 @interface NotificationCenterDelegate : NSObject<NSUserNotificationCenterDelegate> {

--- a/notification_center_delegate.mm
+++ b/notification_center_delegate.mm
@@ -13,10 +13,12 @@ static void AsyncSendHandler(uv_async_t *handle) {
   Nan::HandleScope scope;
   NotificationActivationInfo *info = static_cast<NotificationActivationInfo *>(handle->data);
 
+  NSLog(@"Invoked notification with id: %s", info->id);
+
   v8::Local<v8::Value> argv[3] = {
     Nan::New(info->isReply),
     Nan::New(info->response).ToLocalChecked(),
-    Nan::New(info->id).ToLocalChecked()
+    Nan::New<v8::String>(info->id).ToLocalChecked()
   };
 
   info->callback->Call(3, argv);

--- a/notification_center_delegate.mm
+++ b/notification_center_delegate.mm
@@ -13,12 +13,13 @@ static void AsyncSendHandler(uv_async_t *handle) {
   Nan::HandleScope scope;
   NotificationActivationInfo *info = static_cast<NotificationActivationInfo *>(handle->data);
 
-  v8::Local<v8::Value> argv[2] = {
+  v8::Local<v8::Value> argv[3] = {
     Nan::New(info->isReply),
-    Nan::New(info->response).ToLocalChecked()
+    Nan::New(info->response).ToLocalChecked(),
+    Nan::New(info->id).ToLocalChecked()
   };
 
-  info->callback->Call(2, argv);
+  info->callback->Call(3, argv);
 }
 
 /**
@@ -43,6 +44,7 @@ static void AsyncSendHandler(uv_async_t *handle) {
        didActivateNotification:(NSUserNotification *)notification
 {
   Info.isReply = notification.activationType == NSUserNotificationActivationTypeReplied;
+  Info.id = [notification.identifier cStringUsingEncoding:NSASCIIStringEncoding];
   Info.callback = OnActivation;
 
   if (Info.isReply) {

--- a/notification_center_delegate.mm
+++ b/notification_center_delegate.mm
@@ -18,7 +18,7 @@ static void AsyncSendHandler(uv_async_t *handle) {
   v8::Local<v8::Value> argv[3] = {
     Nan::New(info->isReply),
     Nan::New(info->response).ToLocalChecked(),
-    Nan::New<v8::String>(info->id).ToLocalChecked()
+    Nan::New(info->id).ToLocalChecked()
   };
 
   info->callback->Call(3, argv);
@@ -46,7 +46,7 @@ static void AsyncSendHandler(uv_async_t *handle) {
        didActivateNotification:(NSUserNotification *)notification
 {
   Info.isReply = notification.activationType == NSUserNotificationActivationTypeReplied;
-  Info.id = [notification.identifier cStringUsingEncoding:NSASCIIStringEncoding];
+  Info.id = strdup(notification.identifier.UTF8String);
   Info.callback = OnActivation;
 
   if (Info.isReply) {


### PR DESCRIPTION
Introduces the following fixes:
- The delegate is still set every single time a notification is made, but it now passes the id of the original notification back to the JavaScript context.
- Notifications are saved inside the JavaScript context and compared against the id passed back by the delegate to ensure that the event is emitted on the right notification.
- Once a notification is cleared, we do not free up the delegate. This ensures that there's always a delegate around to handle a notification activation. 