### PR TITLE
Fix compilation on node 10

### DIFF
--- a/mac_notification.mm
+++ b/mac_notification.mm
@@ -37,7 +37,7 @@ MacNotification::MacNotification(Nan::Utf8String *id,
   Nan::Utf8String *soundName,
   bool canReply,
   Nan::Utf8String *otherButtonTitle)
-  : _id(id), _title(title), _subtitle(subtitle), _body(body), _icon(icon), _soundName(soundName), _canReply(canReply), _otherButtonTitle(otherButtonTitle) {
+  : _id(id), _title(title), _subtitle(subtitle), _body(body), _icon(icon), _soundName(soundName), _otherButtonTitle(otherButtonTitle), _canReply(canReply) {
 
   NSUserNotification *notification = [[NSUserNotification alloc] init];
 
@@ -104,7 +104,7 @@ NAN_METHOD(MacNotification::New) {
     const int argc = 1;
     Local<Value> argv[argc] = {info[0]};
     Local<Function> cons = Nan::New(constructor);
-    info.GetReturnValue().Set(cons->NewInstance(argc, argv));
+    info.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Charlie Hess",
   "devDependencies": {
     "mocha": "^2.2.5",
-    "nan": "^2.3.5",
+    "nan": "^2.10.0",
     "node-gyp": "^3.4.0"
   },
   "dependencies": {


### PR DESCRIPTION
This uses the nan wrapper for instance construction so should be backwards compatible.

I also updated the order of field initialization to avoid a warning.