### PR TITLE
Fix deprecated NewInstance usage

### DIFF
--- a/mac_notification.mm
+++ b/mac_notification.mm
@@ -104,7 +104,7 @@ NAN_METHOD(MacNotification::New) {
     const int argc = 1;
     Local<Value> argv[argc] = {info[0]};
     Local<Function> cons = Nan::New(constructor);
-    info.GetReturnValue().Set(cons->NewInstance(argc, argv));
+    info.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
   }
 }
 


### PR DESCRIPTION
This small change fixes the long, long deprecated usage of `NewInstance`, replacing it with the current syntax.

This is required to allow this module to compile with Node 10 and Electron 3.