### PR TITLE
Add a click handler for the "other" / close button

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Additional parameters to the notification.
 * #### `options.canReply` (bool)
   If true, this notification will have a reply action button, and can emit the `reply` event. Maps to `NSUserNotification.hasReplyButton`.
 
+* #### `options.otherButtonTitle` (string)
+  Label for the close button on the notification. Listen for clicks on this button by adding an event listener for `other`.
+
 * #### `options.bundleId` (string)
   Set this to override the `NSBundle.bundleIdentifier` used for the notification. This is a brute force way for your notifications to take on the appropriate app icon.
 

--- a/index.js
+++ b/index.js
@@ -18,12 +18,14 @@ module.exports = class Notification extends EventTarget {
     options.body = options.body || '';
     options.canReply = !!options.canReply;
 
-    const activated = (isReply, response, id) => {
+    const activated = (isReply, response, id, isOtherButton) => {
       const notification = this.getNotificationById(id);
       if (!notification) return;
 
       if (isReply) {
         notification.dispatchEvent({ type: 'reply', response });
+      } else if (isOtherButton) {
+        notification.dispatchEvent({ type: 'other' });
       } else {
         notification.dispatchEvent({ type: 'click' });
       }

--- a/notification_center_delegate.h
+++ b/notification_center_delegate.h
@@ -15,4 +15,7 @@
 - (void)userNotificationCenter:(NSUserNotificationCenter *)center
        didActivateNotification:(NSUserNotification *)notification;
 
+- (void)userNotificationCenter:(NSUserNotificationCenter *)center
+       didDismissAlert:(NSUserNotification *)alert;
+
 @end


### PR DESCRIPTION
This adds the ability to handle clicks on the other button by adding a handler for `didDismissAlert`. I'm not a mac developer, so it's totally possible this could add an unintended side effect, but it works in my testing.